### PR TITLE
Remove sample_rag version from PROMPT_VERSIONS

### DIFF
--- a/app/src/app_config.py
+++ b/app/src/app_config.py
@@ -29,7 +29,6 @@ class AppConfig(PydanticBaseEnvConfig):
     # Version ids are base64 encodings of 'PromptVersion:N' where N is simply a counter,
     # so they are not unique across different Phoenix instances.
     PROMPT_VERSIONS: dict = {
-        "sample_rag": "UHJvbXB0VmVyc2lvbjox",
         "extract_supports": "UHJvbXB0VmVyc2lvbjoz",
         "generate_referrals": "UHJvbXB0VmVyc2lvbjo2",
     }


### PR DESCRIPTION
## Ticket

n/a

## Changes

I deleted the `sample_rag` prompt in Phoenix and realized it is referenced in the code, so removed the reference here


## Context for reviewers

I can't recreate `sample_rag`  to fix this, because it'll have a different version id (since the ID is incremented across all prompts).


## Testing
n/a