### PR TITLE
ci: Improve preview environment URLs

### DIFF
--- a/bin/update-pr-environment
+++ b/bin/update-pr-environment
@@ -36,10 +36,25 @@ echo "Wait for service ${service_name} to become stable"
 aws ecs wait services-stable --cluster "${cluster_name}" --services "${service_name}"
 
 service_endpoint="$(terraform -chdir="infra/${app_name}/service" output -raw service_endpoint)"
+
+# Determine display name
+if [[ "${app_name}" == "app" ]]; then
+  display_name="API"
+else
+  display_name="${app_name}"
+fi
+
+# Determine URL suffix
+if [[ "${app_name}" == "frontend" ]]; then
+  url_suffix="/generate-referrals"
+else
+  url_suffix="/docs"
+fi
+
 pr_info=$(cat <<EOF
 <!-- ${app_name} - begin PR environment info -->
-## Preview environment for ${app_name}
-- Service endpoint: ${service_endpoint}
+## Preview environment for ${display_name}
+- Service endpoint: ${service_endpoint}${url_suffix}
 - Deployed commit: ${image_tag}
 <!-- ${app_name} - end PR environment info -->
 EOF


### PR DESCRIPTION
## Ticket

n/a


## Changes

Small fix to make the preview environment URLs a bit more friendly.


## Context for reviewers
 - I'd like to change the overall name `app` to `api` but that's a much bigger change, this feels like a simple improvement

<!-- frontend - begin PR environment info -->
## Preview environment for frontend
- Service endpoint: https://p-37-frontend-dev-2144518018.us-east-1.elb.amazonaws.com/generate-referrals
- Deployed commit: aea54fc607fa7d1d6d15961d559165339a57aa68
<!-- frontend - end PR environment info -->

<!-- app - begin PR environment info -->
## Preview environment for API
- Service endpoint: https://p-37-app-dev-1175680923.us-east-1.elb.amazonaws.com/docs
- Deployed commit: aea54fc607fa7d1d6d15961d559165339a57aa68
<!-- app - end PR environment info -->